### PR TITLE
Switch to use env vars rather than settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,34 +50,17 @@ Using in a Django logging configuration:
 Dependencies
 ------------
 
-This package uses for kubi_ecs_logger https://github.com/kumina/kubi_ecs_logger for base ECS formatting
+This package uses for kubi_ecs_logger https://github.com/kumina/kubi_ecs_logger for base ECS formatting.
+
+This package uses Django IPware https://github.com/un33k/django-ipware for IP address capture.
 
 This package is compatible with django-user_agents https://pypi.org/project/django-user-agents/ which, when used, will enhance logged user agent information.
 
-Settings
---------
-The formatter checks the setting LOG_SENSITIVE_USER_DATA to see if user information should be logged. If this is not set to true, only the user's id is logged.
+Environment variables
+-------------
+To set the application name within ECS define the DLFE_APP_NAME environment variable.
 
-The Django configuration file logged is determined by running:
-
-.. code-block:: python
-
-     os.getenv('DJANGO_SETTINGS_MODULE')
-
-
-You can set which formatter maps to which Django log by setting the ECS_FORMATTERS settings variable.
-
-This defaults to:
-
-.. code-block:: python
-
-    ECS_FORMATTERS = {
-        "root": ECSSystemFormatter,
-        "django.request": ECSRequestFormatter,
-        "django.db.backends": ECSSystemFormatter,
-    }
-
-And can be used to wire up custom formatters (see next section).
+The formatter checks the setting DLFE_LOG_SENSITIVE_USER_DATA to see if user information should be logged. If this is not set to true, only the user's id is logged.
 
 Creating a custom formatter
 ---------------------------
@@ -93,8 +76,6 @@ If you wish to create your own ECS formatter, you can inherit from ECSSystemForm
             # Customise logger event
 
             return logger_event
-
-This can then be wired up to the list of ECS formatters used (see documentation of ECS_FORMATTERS for more information).
 
 Tests
 -----

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.rst", "r") as fh:
 
 setup(
     name="django_log_formatter_ecs",
-    version="0.0.2",
+    version="0.0.3",
     packages=setuptools.find_packages(),
     author="Ross Miller",
     author_email="ross.miller@digita.trade.gov.uk",
@@ -17,7 +17,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/x-rst",
     install_requires=[
-        "django-ipware>=2.1.0",
+        "django-ipware==2.1.0",
         "kubi-ecs-logger>=0.0.6",
     ],
     classifiers=[

--- a/tests.py
+++ b/tests.py
@@ -1,20 +1,35 @@
+import os
 import json
 import logging
 from io import BytesIO, StringIO
 from unittest import TestCase
+from unittest.mock import patch
 
 from django.conf import settings
 from django.core.handlers.wsgi import WSGIRequest
+
+from django_log_formatter_ecs import ECSFormatter
 
 settings.configure(
     DEBUG=True,
     ALLOWED_HOSTS="*",
 )
 
-from django_log_formatter_ecs import ECSFormatter
+
+class User:
+    def __init__(self, email, user_id, first_name, last_name, username):
+        self.email = email
+        self.id = user_id
+        self.first_name = first_name
+        self.last_name = last_name
+        self.username = username
+
+    def get_full_name(self):
+        return f"{self.first_name} {self.last_name}"
 
 
 class ECSFormatterTest(TestCase):
+
     def create_logger(self, logger_name):
         log_buffer = StringIO()
         ecs_handler = logging.StreamHandler(log_buffer)
@@ -35,23 +50,65 @@ class ECSFormatterTest(TestCase):
 
         assert output["event"]["message"] == "Test"
 
-    def test_request_formatting(self):
+    def _create_request_log(self, add_user=False):
+        request = WSGIRequest({
+            "SERVER_NAME": "test.com",
+            "SERVER_PORT": "443",
+            "PATH_INFO": "test",
+            "REQUEST_METHOD": "test",
+            "CONTENT_TYPE": "text/html; charset=utf8",
+            "wsgi.input": BytesIO(b''),
+        })
+
+        if add_user:
+            user = User(
+                email="test@test.com",
+                user_id=1,
+                first_name="John",
+                last_name="Test",
+                username="johntest",
+            )
+            setattr(request, 'user', user)
+
         logger, log_buffer = self.create_logger("django.request")
         logger.error(
             msg="Request test",
             extra={
-                "request": WSGIRequest({
-                    "SERVER_NAME": "test.com",
-                    "SERVER_PORT": "443",
-                    "PATH_INFO": "test",
-                    "REQUEST_METHOD": "test",
-                    "CONTENT_TYPE": "text/html; charset=utf8",
-                    "wsgi.input": BytesIO(b''),
-                }),
+                "request": request,
             }
         )
 
         json_output = log_buffer.getvalue()
-        output = json.loads(json_output)
+        return json.loads(json_output)
+
+    def test_request_formatting(self):
+        output = self._create_request_log()
 
         assert output["event"]["message"] == "Request test"
+
+    def test_log_sensitive_user_data_default(self):
+        output = self._create_request_log(add_user=True)
+
+        assert "id" in output["user"]
+        assert "email" not in output["user"]
+
+    @patch.dict(os.environ, {'DLFE_LOG_SENSITIVE_USER_DATA': 'True'})
+    def test_log_sensitive_user_data_on(self):
+        output = self._create_request_log(add_user=True)
+
+        assert output["user"]["id"] == "1"
+        assert output["user"]["email"] == "test@test.com"
+        assert output["user"]["full_name"] == "John Test"
+        assert output["user"]["name"] == "johntest"
+
+    @patch.dict(os.environ, {'DLFE_APP_NAME': 'TestApp'})
+    def test_app_name_log_value(self):
+        output = self._create_request_log()
+
+        assert output["event"]["labels"]["application"] == "TestApp"
+
+    @patch.dict(os.environ, {'DJANGO_SETTINGS_MODULE': 'settings.Test'})
+    def test_env_log_value(self):
+        output = self._create_request_log()
+
+        assert output["event"]["labels"]["env"] == "settings.Test"


### PR DESCRIPTION
The original logic relied on settings which, when used with a single settings file caused a circular import rendering the project unusable.

This version switches to configuration using env vars avoiding the circular import issue.