### PR TITLE
Drop Python 3.6 and 3.7, add 3.10, 3.11 and 3.12

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py36,py37,py38
+envlist=py37,py38,py39,py310,py311,py312
 
 [testenv]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py37,py38,py39,py310,py311,py312
+envlist=py38,py39,py310,py311,py312
 
 [testenv]
 deps=


### PR DESCRIPTION
I wanted to check if this package is OK with newer versions of Python. It is 🎉 

tox can't handle Python 3.6...

```
ERROR: InvocationError: Failed to get version_info for python3.6: b"pyenv: python3.6: command not found

The `python3.6' command exists in these Python versions:
  3.6.15

Note: See 'pyenv help global' for tips on allowing both
      python2 and python3 to be found."
```

I'm hoping we don't need to support Python 3.6 so we can just remove it.